### PR TITLE
doc: added missing default mapping `co` for `choose ours`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ If you would rather not use these then disable default mappings an you can then 
 
 ```lua
 vim.keymap.set('n', 'co', '<Plug>(git-conflict-ours)')
+vim.keymap.set('n', 'ct', '<Plug>(git-conflict-theirs)')
 vim.keymap.set('n', 'cb', '<Plug>(git-conflict-both)')
 vim.keymap.set('n', 'c0', '<Plug>(git-conflict-none)')
-vim.keymap.set('n', 'ct', '<Plug>(git-conflict-theirs)')
-vim.keymap.set('n', '[x', '<Plug>(git-conflict-next-conflict)')
 vim.keymap.set('n', ']x', '<Plug>(git-conflict-prev-conflict)')
+vim.keymap.set('n', '[x', '<Plug>(git-conflict-next-conflict)')
 ```
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This plugin offers default buffer local mappings inside of conflicted files. Thi
 is not possible through global mappings. A user can however disable these by setting `default_mappings = false` anyway and create global mappings as shown below.
 The default mappings are:
 
+- <kbd>c</kbd><kbd>o</kbd> - choose ours
 - <kbd>c</kbd><kbd>t</kbd> - choose theirs
 - <kbd>c</kbd><kbd>b</kbd> - choose both
 - <kbd>c</kbd><kbd>0</kbd> - choose none

--- a/create_conflict.sh
+++ b/create_conflict.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 [ -d ./../conflict-test/ ] && rm -rf ./conflict-test/
 mkdir conflict-test
-cd conflict-test
+cd conflict-test || exit
 git init
 touch conflicted.lua
 git add conflicted.lua


### PR DESCRIPTION
Hello akinsho! Thank you for creating such an awesome tool. It makes resolving git conflict less error-prone:)
Here's some changes I hope you'd find useful:

```
commit ceb5f9b115083033cbff662279085e618ec8c74d
    shellcheck: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

commit b4e3cd6a764b0b20d5fd4a57031d132b21c23603
    added missing default mapping `co` for `choose ours`

commit e79e7e9eb8b326833e64f7f6e0753eb2b2d0963b
    lua mapping list same order as default mapping
```