### PR TITLE
fix: Reverse hl groups and adjust shade

### DIFF
--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -290,15 +290,15 @@ local function set_highlights(highlights)
   local current_bg = current_color.background or DEFAULT_CURRENT_BG_COLOR
   local incoming_bg = incoming_color.background or DEFAULT_INCOMING_BG_COLOR
   local ancestor_bg = ancestor_color.background or DEFAULT_ANCESTOR_BG_COLOR
-  local current_label_bg = color.shade_color(current_bg, -10)
-  local incoming_label_bg = color.shade_color(incoming_bg, -10)
-  local ancestor_label_bg = color.shade_color(ancestor_bg, -10)
-  api.nvim_set_hl(0, CURRENT_LABEL_HL, { background = current_bg, bold = true })
-  api.nvim_set_hl(0, INCOMING_LABEL_HL, { background = incoming_bg, bold = true })
-  api.nvim_set_hl(0, ANCESTOR_LABEL_HL, { background = ancestor_bg, bold = true })
-  api.nvim_set_hl(0, CURRENT_HL, { background = current_label_bg })
-  api.nvim_set_hl(0, INCOMING_HL, { background = incoming_label_bg })
-  api.nvim_set_hl(0, ANCESTOR_HL, { background = ancestor_label_bg })
+  local current_label_bg = color.shade_color(current_bg, 60)
+  local incoming_label_bg = color.shade_color(incoming_bg, 60)
+  local ancestor_label_bg = color.shade_color(ancestor_bg, 60)
+  api.nvim_set_hl(0, CURRENT_HL, { background = current_bg, bold = true })
+  api.nvim_set_hl(0, INCOMING_HL, { background = incoming_bg, bold = true })
+  api.nvim_set_hl(0, ANCESTOR_HL, { background = ancestor_bg, bold = true })
+  api.nvim_set_hl(0, CURRENT_LABEL_HL, { background = current_label_bg })
+  api.nvim_set_hl(0, INCOMING_LABEL_HL, { background = incoming_label_bg })
+  api.nvim_set_hl(0, ANCESTOR_LABEL_HL, { background = ancestor_label_bg })
 end
 
 ---Highlight each part of a git conflict i.e. the incoming changes vs the current/HEAD changes


### PR DESCRIPTION
Resolves: https://github.com/akinsho/git-conflict.nvim/issues/19

## Description
- The highlight groups were reversed, I adjusted them so they were set to the proper colors
- WIth the hl groups reversed, `DiffAdd` and `DiffText` represented the bg for the code and not labels.  The labels are brighter than the code in vscode so I flipped the "dimming" -10 value for a brighting "60".

## Screens
|Before|After|vscode|
|-|-|-|
|![image](https://user-images.githubusercontent.com/9698979/171849620-e44e5dce-59bb-4216-bf48-6344d8531b81.png)|![image](https://user-images.githubusercontent.com/9698979/171849360-94537212-a6f8-4feb-9668-e0ef8e284d23.png)|![image](https://user-images.githubusercontent.com/9698979/171849419-fcefbde2-b353-4e28-a6b0-7dc651707942.png)|

## Notes
I tested by setting the following `DiffAdd` and `DiffText` hl values.

```lua
vim.api.nvim_set_hl(0, 'DiffText', { fg = "#ffffff", bg = "#1d3b40" })
vim.api.nvim_set_hl(0, 'DiffAdd', { fg = "#ffffff", bg = "#1d3450" })
```