### PR TITLE
refactor: add git directory watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 git-repo/
+conflict-test/

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+    "Lua.diagnostics.globals": [
+        "vim",
+        "describe",
+        "it",
+        "before_each",
+        "after_each",
+        "packer_plugins",
+        "lfs"
+    ],
+    "Lua.workspace.checkThirdParty": false
+}

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -425,7 +425,7 @@ end
 
 local function set_commands()
   local command = api.nvim_create_user_command
-  command('GitConflictRefresh',function ()
+  command('GitConflictRefresh', function()
     fetch_conflicts()
   end, { nargs = 0 })
   command('GitConflictListQf', function()

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -433,18 +433,24 @@ local on_throttled_change = utils.throttle(5000, function(watcher, callback, err
   end
   fetch_conflicts()
   watcher:stop()
-  callback(dir)
+  callback()
 end)
 
-local function watch_gitdir(dir)
+--- Stop any watchers that aren't for the current project
+---@param dir string
+local function toggle_dir_watchers(dir)
   for _, w in pairs(watchers) do
     if w ~= watchers[dir] then
       w:stop()
     end
   end
+end
 
-  local function callback(d)
-    watch_gitdir(d)
+--- Create a FS watcher for the current git directory or restart an existing one
+---@param dir string
+local function watch_gitdir(dir)
+  local function callback()
+    watch_gitdir(dir)
   end
 
   ---@type userdata
@@ -632,6 +638,7 @@ function M.setup(user_config)
       if fn.isdirectory(gitdir) == 0 then
         return
       end
+      toggle_dir_watchers(gitdir)
       fetch_conflicts()
       throttled_watcher(gitdir)
     end,

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -422,6 +422,10 @@ end
 local watchers = {}
 
 local on_throttled_change = utils.throttle(5000, function(watcher, callback, err, dir, status)
+  -- FIXME: this should be a debug log only visible to me
+  vim.notify(fmt('Responding to FS change in %s', dir), 'info', {
+    title = 'Git Conflict',
+  })
   if err then
     return vim.notify(fmt('Error watching %s(%s): %s', dir, err, status), 'error', {
       title = 'Git Conflict',

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -394,6 +394,8 @@ local function fetch_conflicts()
   end
   local seen = {}
   for _, b in ipairs(api.nvim_list_bufs()) do
+    -- FIXME: find a better way to get the project root for each buffer
+    -- e.g. vim.fs.find('.git', {upwards = true})[1]
     local dir = fn.fnamemodify(api.nvim_buf_get_name(b), ':p:h')
     if not seen[dir] then
       get_conflicted_files(dir, function(files, repo)

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -422,10 +422,6 @@ end
 local watchers = {}
 
 local on_throttled_change = utils.throttle(5000, function(watcher, callback, err, dir, status)
-  -- FIXME: this should be a debug log only visible to me
-  vim.notify(fmt('Responding to FS change in %s', dir), 'info', {
-    title = 'Git Conflict',
-  })
   if err then
     return vim.notify(fmt('Error watching %s(%s): %s', dir, err, status), 'error', {
       title = 'Git Conflict',

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -636,6 +636,16 @@ function M.setup(user_config)
     end,
   })
 
+  api.nvim_create_autocmd('VimLeavePre', {
+    group = AUGROUP_NAME,
+    callback = function()
+      for key, watcher in pairs(watchers) do
+        watcher:stop()
+        watchers[key] = nil
+      end
+    end,
+  })
+
   api.nvim_create_autocmd('User', {
     group = AUGROUP_NAME,
     pattern = 'GitConflictDetected',

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -417,7 +417,7 @@ end
 ---@type table<string, userdata>
 local watchers = {}
 
-local on_throttled_change = utils.throttle(5000, function(watcher, callback, err, dir, status)
+local on_throttled_change = utils.throttle(1000, function(watcher, callback, err, dir, status)
   if err then
     return vim.notify(fmt('Error watching %s(%s): %s', dir, err, status), 'error', {
       title = 'Git Conflict',

--- a/lua/git-conflict/colors.lua
+++ b/lua/git-conflict/colors.lua
@@ -16,9 +16,7 @@ local function decode_24bit_rgb(rgb_24bit)
   return { r = r, g = g, b = b }
 end
 
-local function alter(attr, percent)
-  return math.floor(attr * (100 + percent) / 100)
-end
+local function alter(attr, percent) return math.floor(attr * (100 + percent) / 100) end
 
 ---@source https://stackoverflow.com/q/5560248
 ---@see: https://stackoverflow.com/a/37797380
@@ -28,9 +26,7 @@ end
 ---@return string
 function M.shade_color(color, percent)
   local rgb = decode_24bit_rgb(color)
-  if not rgb.r or not rgb.g or not rgb.b then
-    return 'NONE'
-  end
+  if not rgb.r or not rgb.g or not rgb.b then return 'NONE' end
   local r, g, b = alter(rgb.r, percent), alter(rgb.g, percent), alter(rgb.b, percent)
   r, g, b = math.min(r, 255), math.min(g, 255), math.min(b, 255)
   return string.format('#%02x%02x%02x', r, g, b)

--- a/lua/git-conflict/utils.lua
+++ b/lua/git-conflict/utils.lua
@@ -16,7 +16,7 @@ function M.job(cmd, callback)
 end
 
 ---Only call the passed function once every timeout in ms
----@param timeout number
+---@param timeout integer
 ---@param func function
 ---@return function
 function M.throttle(timeout, func)
@@ -34,23 +34,23 @@ function M.throttle(timeout, func)
 end
 
 ---Wrapper around `api.nvim_buf_get_lines` which defaults to the current buffer
----@param start number
----@param _end number
----@param buf number?
+---@param start integer
+---@param _end integer
+---@param buf integer?
 ---@return string[]
 function M.get_buf_lines(start, _end, buf)
   return api.nvim_buf_get_lines(buf or 0, start, _end, false)
 end
 
 ---Get cursor row and column as (1, 0) based
----@param win_id number?
----@return number, number
+---@param win_id integer?
+---@return integer, integer
 function M.get_cursor_pos(win_id)
   return unpack(api.nvim_win_get_cursor(win_id or 0))
 end
 
 ---Check if the buffer is likely to have actionable conflict markers
----@param bufnr number?
+---@param bufnr integer?
 ---@return boolean
 function M.is_valid_buf(bufnr)
   bufnr = bufnr or 0
@@ -58,7 +58,7 @@ function M.is_valid_buf(bufnr)
 end
 
 ---@param name string?
----@return table<string, boolean|number|string>
+---@return table<string, string>
 function M.get_hl(name)
   if not name then
     return {}

--- a/lua/git-conflict/utils.lua
+++ b/lua/git-conflict/utils.lua
@@ -9,9 +9,7 @@ local fn = vim.fn
 function M.job(cmd, callback)
   fn.jobstart(cmd, {
     stdout_buffered = true,
-    on_stdout = function(_, data, _)
-      callback(data)
-    end,
+    on_stdout = function(_, data, _) callback(data) end,
   })
 end
 
@@ -26,9 +24,7 @@ function M.throttle(timeout, func)
     if not running then
       func(...)
       running = true
-      timer:start(timeout, 0, function()
-        running = false
-      end)
+      timer:start(timeout, 0, function() running = false end)
     end
   end
 end
@@ -45,9 +41,7 @@ end
 ---Get cursor row and column as (1, 0) based
 ---@param win_id integer?
 ---@return integer, integer
-function M.get_cursor_pos(win_id)
-  return unpack(api.nvim_win_get_cursor(win_id or 0))
-end
+function M.get_cursor_pos(win_id) return unpack(api.nvim_win_get_cursor(win_id or 0)) end
 
 ---Check if the buffer is likely to have actionable conflict markers
 ---@param bufnr integer?
@@ -60,9 +54,7 @@ end
 ---@param name string?
 ---@return table<string, string>
 function M.get_hl(name)
-  if not name then
-    return {}
-  end
+  if not name then return {} end
   return api.nvim_get_hl_by_name(name, true)
 end
 

--- a/stylua.toml
+++ b/stylua.toml
@@ -3,4 +3,4 @@ indent_type = 'Spaces'
 quote_style = 'AutoPreferSingle'
 indent_width = 2
 no_call_parentheses = false
-
+collapse_simple_statement = "Always"


### PR DESCRIPTION
Rather than triggering on every `BufEnter` and doing a lot of unnecessary work, constantly this plugin should check on `VimEnter`, `SessionLoadPost`, `DirChanged` and otherwise wait for FS events from the `.git` directory. This reduces the amount of work this plugin does