### PR TITLE
docs(README): add missing comma to autocommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ e.g.
 
 ```lua
 vim.api.nvim_create_autocommand('User', {
-  pattern = 'GitConflictDetected'
+  pattern = 'GitConflictDetected',
   callback = function()
     vim.notify('Conflict detected in '..vim.fn.expand('<afile>'))
     vim.keymap.set('n', 'cww', function()


### PR DESCRIPTION
Tweak to add missing comma to autocommand.