### PR TITLE
fix: show correct defaults in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ I recommend using the {tag|version} field of your package manager, so your versi
   default_commands = true, -- disable commands created by this plugin
   disable_diagnostics = false, -- This will disable the diagnostics in a buffer whilst it is conflicted
   highlights = { -- They must have background color, otherwise the default color will be used
-    incoming = 'DiffText',
-    current = 'DiffAdd',
+    incoming = 'DiffAdd',
+    current = 'DiffText',
   }
 }
 ```


### PR DESCRIPTION
The README has different defaults in the configuration than what they actually are