### PR TITLE
Add conflict_count function

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ vim.keymap.set('n', '[x', '<Plug>(git-conflict-next-conflict)')
 
 </details>
 
+## API
+
+This plugin exposes an API to extract some of the data it collects for other
+purposes.
+
+<details><summary>conflict_count({bufnr})</summary>
+
+```vimdoc
+    Returns the amount of conflicts in a given buffer.
+    
+
+    Parameters:
+	{bufnr} (number) Specify the buffer for which you want to know the
+	                 amount of conflicts (default: current buffer).
+
+    Return:
+	number: The amount of conflicts.
+```
+</details>
+
 ## Issues
 
 **Please read this** — This plugin is not intended to do anything other than provide fancy visuals, and some mappings to handle conflict resolution

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -775,4 +775,14 @@ end
 
 function M.debug_watchers() vim.pretty_print({ watchers = watchers }) end
 
+function M.conflict_count(bufnr)
+  if bufnr and not api.nvim_buf_is_valid(bufnr) then return 0 end
+  bufnr = bufnr or 0
+
+  local name = api.nvim_buf_get_name(bufnr)
+  if not visited_buffers[name] then return 0 end
+
+  return #visited_buffers[name].positions
+end
+
 return M


### PR DESCRIPTION
This PR adds a simple function that returns the amount of conflicts in a buffer. This can be useful to for example display the amount of conflicts in your statusline. Since git-conflict is already keeping track of this anyway its nice to be able to reuse that information.