### PR TITLE
Fix typo in README code snippet for auto commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Either of these can be used to run logic whilst dealing with conflicts
 e.g.
 
 ```lua
-vim.api.nvim_create_autocommand('User', {
+vim.api.nvim_create_autocmd('User', {
   pattern = 'GitConflictDetected',
   callback = function()
     vim.notify('Conflict detected in '..vim.fn.expand('<afile>'))


### PR DESCRIPTION
The `nvim_create_autocmd` function in the README.md auto command code snippet contained a typo, which I fixed.