### PR TITLE
Fix #30, add support for git worktrees

### DIFF
--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -617,7 +617,7 @@ function M.setup(user_config)
     group = AUGROUP_NAME,
     callback = function(args)
       local gitdir = fn.getcwd() .. sep .. '.git'
-      if fn.isdirectory(gitdir) == 0 or state.current_watcher_dir == fn.getcwd() then return end
+      if not vim.loop.fs_stat(gitdir) or state.current_watcher_dir == fn.getcwd() then return end
       stop_running_watchers(gitdir)
       fetch_conflicts(args.buf)
       throttled_watcher(gitdir)


### PR DESCRIPTION
For git worktrees, `.git` is actually a file, not a directory.

I modified `create_conflict.sh` for testing it with worktrees:
``` bash
#!/bin/bash
[ -d ./../conflict-test/ ] && rm -rf ./conflict-test/
mkdir conflict-test
cd conflict-test || exit
git init
touch conflicted.lua
git add conflicted.lua
echo "local value = 1 + 1" > conflicted.lua
git commit -am 'initial'
git checkout -b new_branch
echo "local value = 1 - 1" > conflicted.lua
git commit -am 'first commit on new_branch'
git checkout main
cat > conflicted.lua<< EOF
local value = 5 + 7
print(value)
print(string.format("value is %d", value))
EOF
git commit -am 'second commit on main'
git switch new_branch
git worktree add ../worktree-test main
(cd ../worktree-test && git merge new_branch)
```