### PR TITLE
fix: swap mappings for prev/next conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The default mappings are:
 - <kbd>c</kbd><kbd>t</kbd> — choose theirs
 - <kbd>c</kbd><kbd>b</kbd> — choose both
 - <kbd>c</kbd><kbd>0</kbd> — choose none
-- <kbd>]</kbd><kbd>x</kbd> — move to previous conflict
-- <kbd>[</kbd><kbd>x</kbd> — move to next conflict
+- <kbd>[</kbd><kbd>x</kbd> — move to previous conflict
+- <kbd>]</kbd><kbd>x</kbd> — move to next conflict
 
 If you would rather not use these then you can specify your own mappings.
 
@@ -122,8 +122,8 @@ vim.keymap.set('n', 'co', '<Plug>(git-conflict-ours)')
 vim.keymap.set('n', 'ct', '<Plug>(git-conflict-theirs)')
 vim.keymap.set('n', 'cb', '<Plug>(git-conflict-both)')
 vim.keymap.set('n', 'c0', '<Plug>(git-conflict-none)')
-vim.keymap.set('n', ']x', '<Plug>(git-conflict-prev-conflict)')
-vim.keymap.set('n', '[x', '<Plug>(git-conflict-next-conflict)')
+vim.keymap.set('n', '[x', '<Plug>(git-conflict-prev-conflict)')
+vim.keymap.set('n', ']x', '<Plug>(git-conflict-next-conflict)')
 ```
 
 </details>

--- a/doc/git-conflict.txt
+++ b/doc/git-conflict.txt
@@ -124,8 +124,8 @@ The default mappings are:
 - ct — choose theirs
 - cb — choose both
 - c0 — choose none
-- ]x — move to previous conflict
-- [x — move to next conflict
+- [x — move to previous conflict
+- ]x — move to next conflict
 
 If you would rather not use these then you can specify your own mappings.
 
@@ -152,8 +152,8 @@ example manual mappings ~
     vim.keymap.set('n', 'ct', '<Plug>(git-conflict-theirs)')
     vim.keymap.set('n', 'cb', '<Plug>(git-conflict-both)')
     vim.keymap.set('n', 'c0', '<Plug>(git-conflict-none)')
-    vim.keymap.set('n', ']x', '<Plug>(git-conflict-prev-conflict)')
-    vim.keymap.set('n', '[x', '<Plug>(git-conflict-next-conflict)')
+    vim.keymap.set('n', '[x', '<Plug>(git-conflict-prev-conflict)')
+    vim.keymap.set('n', ']x', '<Plug>(git-conflict-next-conflict)')
 <
 
 

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -128,8 +128,8 @@ local DEFAULT_MAPPINGS = {
   theirs = 'ct',
   none = 'c0',
   both = 'cb',
-  next = '[x',
-  prev = ']x',
+  next = ']x',
+  prev = '[x',
 }
 
 --- @type GitConflictConfig


### PR DESCRIPTION
It was initally fixed in https://github.com/akinsho/git-conflict.nvim/commit/c3230fd0322b3d8e47b85478251f83d4587bdca5 as part of issue #13. But after that in another refactoring commit it got reverted back
https://github.com/akinsho/git-conflict.nvim/commit/c92604a64a2cce15a6e6a753f4501bcee06fa00a#diff-2b380ab7418218b1caeedb80bb559f8d3c1d052d7a84ebd73cab431ae7541eefR129-R130 as part of #42.