### PR TITLE
fix: off-by-one error in find_position

### DIFF
--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -342,6 +342,7 @@ local function find_position(bufnr, comparator, opts)
   local match = visited_buffers[bufnr]
   if not match then return end
   local line = utils.get_cursor_pos()
+  line = line - 1 -- Convert to 0-based for position comparison
 
   if opts and opts.reverse then
     for i = #match.positions, 1, -1 do


### PR DESCRIPTION
This is a fix for https://github.com/akinsho/git-conflict.nvim/issues/84

Two issues:
- You couldn't run a `choose()` command when the cursor was on the final line of a conflict.
- You could run `choose()` when one line above the conflict.

This was due to an off-by-one error in `find_position` when comparing the cursor position to the conflict position. The conflict positions are 0-based, so the line numbers needed to be adjusted down by 1 when making the comparison.