### PR TITLE
fix: extmarks missing from final line

### DIFF
--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -263,7 +263,7 @@ local function highlight_conflicts(positions, lines)
 
     local curr_label_id = draw_section_label(bufnr, CURRENT_LABEL_HL, current_label, current_start)
     local curr_id = hl_range(bufnr, CURRENT_HL, current_start, current_end + 1)
-    local inc_id = hl_range(bufnr, INCOMING_HL, incoming_start, incoming_end)
+    local inc_id = hl_range(bufnr, INCOMING_HL, incoming_start, incoming_end + 1)
     local inc_label_id = draw_section_label(bufnr, INCOMING_LABEL_HL, incoming_label, incoming_end)
 
     position.marks = {


### PR DESCRIPTION
I noticed that while extmarks are present on the first line (`<<<<<<< HEAD`), they are missing from the final line of the incoming changes (`>>>>>>> new_branch`), so I extended them to include it. 

```lua
<<<<<<< HEAD (Current changes)
-- Code
=======
-- Code
>>>>>>> new_branch (Incoming changes)
-- There were no extmarks on this ^^ line
```

Merging this would help with [selecting conflicts by extmark](https://github.com/akinsho/git-conflict.nvim/issues/48#issuecomment-2130694832).