### PR TITLE
fix(mapping)!: swap prev and next mapping for conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ vim.keymap.set('n', 'co', '<Plug>(git-conflict-ours)')
 vim.keymap.set('n', 'ct', '<Plug>(git-conflict-theirs)')
 vim.keymap.set('n', 'cb', '<Plug>(git-conflict-both)')
 vim.keymap.set('n', 'c0', '<Plug>(git-conflict-none)')
-vim.keymap.set('n', ']x', '<Plug>(git-conflict-prev-conflict)')
-vim.keymap.set('n', '[x', '<Plug>(git-conflict-next-conflict)')
+vim.keymap.set('n', '[x', '<Plug>(git-conflict-prev-conflict)')
+vim.keymap.set('n', ']x', '<Plug>(git-conflict-next-conflict)')
 ```
 
 </details>

--- a/doc/git-conflict.txt
+++ b/doc/git-conflict.txt
@@ -124,8 +124,8 @@ The default mappings are:
 - ct — choose theirs
 - cb — choose both
 - c0 — choose none
-- ]x — move to previous conflict
-- [x — move to next conflict
+- [x — move to previous conflict
+- ]x — move to next conflict
 
 If you would rather not use these then you can specify your own mappings.
 
@@ -152,8 +152,8 @@ example manual mappings ~
     vim.keymap.set('n', 'ct', '<Plug>(git-conflict-theirs)')
     vim.keymap.set('n', 'cb', '<Plug>(git-conflict-both)')
     vim.keymap.set('n', 'c0', '<Plug>(git-conflict-none)')
-    vim.keymap.set('n', ']x', '<Plug>(git-conflict-prev-conflict)')
-    vim.keymap.set('n', '[x', '<Plug>(git-conflict-next-conflict)')
+    vim.keymap.set('n', '[x', '<Plug>(git-conflict-prev-conflict)')
+    vim.keymap.set('n', ']x', '<Plug>(git-conflict-next-conflict)')
 <
 
 

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -128,8 +128,8 @@ local DEFAULT_MAPPINGS = {
   theirs = 'ct',
   none = 'c0',
   both = 'cb',
-  next = '[x',
-  prev = ']x',
+  next = ']x',
+  prev = '[x',
 }
 
 --- @type GitConflictConfig


### PR DESCRIPTION
This is a breaking change, but this is more in line with how mappings with brackets are in neovim. See for example:

`]d -> next diagnostic`
`]s -> next misspelled word`
`]r -> next rare word`
`]c -> next diff`

I couldn't find anything to generate the vim-docs, so I just edited them manually😅