### PR TITLE
Fix, simplify, and improve navigation between conflicts

### DIFF
--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -351,12 +351,15 @@ local function find_position(bufnr, comparator, opts)
       local position = match.positions[i]
       if comparator(line, position) then return position end
     end
+    if opts.wrap and match.positions[#match.positions] then return match.positions[#match.positions] end
     return nil
   end
 
   for _, position in ipairs(match.positions) do
     if comparator(line, position) then return position end
   end
+
+  if opts and opts.wrap and match.positions[1] then return match.positions[1] end
   return nil
 end
 
@@ -726,8 +729,9 @@ function M.find_next(side)
   local pos = find_position(
     0,
     function(line, position)
-      return position.current.range_start >= line and position.incoming.range_end >= line
-    end
+      return line < position.current.range_start
+    end,
+    { wrap = true }
   )
   set_cursor(pos, side)
 end
@@ -737,9 +741,9 @@ function M.find_prev(side)
   local pos = find_position(
     0,
     function(line, position)
-      return position.current.range_start <= line and position.incoming.range_end <= line
+      return line > position.current.range_start
     end,
-    { reverse = true }
+    { wrap = true, reverse = true }
   )
   set_cursor(pos, side)
 end

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -351,7 +351,9 @@ local function find_position(bufnr, comparator, opts)
       local position = match.positions[i]
       if comparator(line, position) then return position end
     end
-    if opts.wrap and match.positions[#match.positions] then return match.positions[#match.positions] end
+    if opts.wrap and match.positions[#match.positions] then
+      return match.positions[#match.positions]
+    end
     return nil
   end
 
@@ -728,9 +730,7 @@ end
 function M.find_next(side)
   local pos = find_position(
     0,
-    function(line, position)
-      return line < position.current.range_start
-    end,
+    function(line, position) return line < position.current.range_start end,
     { wrap = true }
   )
   set_cursor(pos, side)
@@ -740,9 +740,7 @@ end
 function M.find_prev(side)
   local pos = find_position(
     0,
-    function(line, position)
-      return line > position.current.range_start
-    end,
+    function(line, position) return line > position.current.range_start end,
     { wrap = true, reverse = true }
   )
   set_cursor(pos, side)


### PR DESCRIPTION
Navigation between conflicts does not feel natural.

Namely, the issues are
* If the cursor is on the start of a conflict (the "<<<<<<<" line), `GitConflictNext` does not navigate to the next conflict.
* If the cursor is inside of a conflict (the "content"), and `GitConflictPrevious` is called, the cursor does not jump to the start of the current conflict (the "<<<<<<<" line).
* If the cursor is on the first conflict of a file and `GitConflictPrevious` is called, or the cursor is on the last conflict of a file and `GitConflictNext` is called, the cursor does not wrap around to the last conflict or first conflict, respectively.

We can resolve these by simplifying the comparator functions in `find_next()` and `find_previous()`.
* To find the next conflict, simply find the first conflict whose start is somewhere below the cursor location, iterating in the order the conflicts appear. If one does not exist, use the first conflict in the file, if it exists.
* To find the previous conflict, simply find the first conflict whose start is somewhere above the cursor location, iterating in the reverse order that the conflicts appear. If one does not exist, use the last conflict in the file, if it exists.