### PR TITLE
fix: deprecated API in 0.10

### DIFF
--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -652,7 +652,7 @@ function M.setup(user_config)
     pattern = 'GitConflictDetected',
     callback = function()
       local bufnr = api.nvim_get_current_buf()
-      if config.disable_diagnostics then vim.diagnostic.disable(bufnr) end
+      if config.disable_diagnostics then vim.diagnostic.enable(false, { bufnr = bufnr }) end
       if config.default_mappings then setup_buffer_mappings(bufnr) end
     end,
   })
@@ -662,7 +662,7 @@ function M.setup(user_config)
     pattern = 'GitConflictResolved',
     callback = function()
       local bufnr = api.nvim_get_current_buf()
-      if config.disable_diagnostics then vim.diagnostic.enable(bufnr) end
+      if config.disable_diagnostics then vim.diagnostic.enable(true, { bufnr = bufnr }) end
       if config.default_mappings then clear_buffer_mappings(bufnr) end
     end,
   })


### PR DESCRIPTION
Removed uses of `vim.diagnostic.disable`, which is deprecated in neovim 0.10