### PR TITLE
Detect the git root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ encounter some bugs during usage.
 ## Requirements
 
 - `git`
-- `nvim 0.7+`
+- `nvim 0.10+`
 
 ## Installation
 

--- a/lua/git-conflict.lua
+++ b/lua/git-conflict.lua
@@ -629,7 +629,9 @@ function M.setup(user_config)
   api.nvim_create_autocmd({ 'VimEnter', 'BufRead', 'SessionLoadPost', 'DirChanged' }, {
     group = AUGROUP_NAME,
     callback = function(args)
-      local gitdir = fn.getcwd() .. sep .. '.git'
+      local gitroot = vim.fs.root(fn.getcwd(), ".git")
+      if not gitroot then return end
+      local gitdir = vim.fs.joinpath(gitroot, ".git")
       if not vim.loop.fs_stat(gitdir) or state.current_watcher_dir == fn.getcwd() then return end
       stop_running_watchers(gitdir)
       fetch_conflicts(args.buf)


### PR DESCRIPTION
Problem: If CWD is not the git root directory, but still inside a git repository, the highlighting only appears after executing `GitConflictRefresh`
Solution: Use `vim.fs.root()` to find the git root directory