### PR TITLE
docs: example LazyVim configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,39 @@ vim.keymap.set('n', ']x', '<Plug>(git-conflict-next-conflict)')
 
 </details>
 
+<details><summary>example LazyVim key configuration</summary>
+
+```lua
+return {
+  {
+    "akinsho/git-conflict.nvim",
+    event = "BufReadPre",
+    opts = {
+      default_mappings = false,
+    },
+    keys = {
+      { "<leader>gco", "<Plug>(git-conflict-ours)", desc = "Choose Ours" },
+      { "<leader>gct", "<Plug>(git-conflict-theirs)", desc = "Choose Theirs" },
+      { "<leader>gcb", "<Plug>(git-conflict-both)", desc = "Choose Both" },
+      { "<leader>gc0", "<Plug>(git-conflict-none)", desc = "Choose None" },
+      { "]x", "<Plug>(git-conflict-next-conflict)", desc = "Next Conflict" },
+      { "[x", "<Plug>(git-conflict-prev-conflict)", desc = "Previous Conflict" },
+      { "<leader>gcq", "<cmd>GitConflictListQf<cr>", desc = "Conflicts to Quickfix" },
+    },
+  },
+  {
+    "folke/which-key.nvim",
+    opts = {
+      spec = {
+        { "<leader>gc", group = "conflict" },
+      },
+    },
+  },
+}
+```
+
+</details>
+
 ## API
 
 This plugin exposes an API to extract some of the data it collects for other


### PR DESCRIPTION
Just a simple PR to showcase how to integrate `git-conflict.nvim` with LazyVim's `which-key` based keybinds.

Besides the key configuration (similar to the vim native one above), they are discoverable in the key bind menu in the bottom left and grouped under a `+conflict` group for `<leader>gc`.